### PR TITLE
Handle non json response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@g-six/kastle-router",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -35,4 +35,28 @@ describe('lambdaHandler', () => {
 
     expect(spyHandler).toHaveBeenCalled()
   })
+
+  it('should process file request and set response body and headers accordingly', () => {
+    const ctx = ({
+      body: {},
+      headers: {},
+      params: {},
+      request: {
+        body: {},
+        headers: {},
+        method: MethodTypes.Get,
+        query: {},
+      },
+      set: jest.fn(),
+    } as unknown) as BaseContext
+
+    const spyHandler = jest.fn(() => ({
+      body: new Buffer('Test').toString('base64'),
+      headers: {},
+      statusCode: 200,
+    }))
+    lambdaMiddleware(spyHandler)(ctx)
+
+    expect(spyHandler).toHaveBeenCalled()
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,17 +42,21 @@ const lambdaMiddleware = (handler: Function) => async (ctx: BaseContext) => {
 
   ctx.set(headers as {})
 
-  const body = JSON.parse(sls_body)
+  try {
+    const body = JSON.parse(sls_body)
+    ctx.body = pick(body, [
+      'message',
+      'data',
+      'error',
+      'errors',
+      'records',
+      'record',
+      'status',
+    ])
+  } catch {
+    ctx.body = sls_body
+  }
 
-  ctx.body = pick(body, [
-    'message',
-    'data',
-    'error',
-    'errors',
-    'records',
-    'record',
-    'status',
-  ])
   ctx.status = statusCode
 }
 


### PR DESCRIPTION
This change is useful if you are sending pure text as response; or base64 strings (files) as response. This change has taken how AWS Lambda and API Gateway handles the response body.